### PR TITLE
fix: pass params while auto pagination is true

### DIFF
--- a/src/http/MindbodyAPIClient.ts
+++ b/src/http/MindbodyAPIClient.ts
@@ -57,6 +57,7 @@ export class MindbodyAPIClient extends BaseClient {
         headers: headers,
         firstPage: res.data,
         objectIndexKey: args.objectIndexKey,
+        params: args.params
       });
     }
 

--- a/src/http/autoPager.ts
+++ b/src/http/autoPager.ts
@@ -33,6 +33,7 @@ export async function autoPager<T extends Returnable>(
         args.client.get(args.endpoint, {
           headers: args.headers,
           params: {
+            ...args.params,
             Offset: offset,
             Limit: limit,
           },
@@ -45,6 +46,7 @@ export async function autoPager<T extends Returnable>(
           args.client.get(args.endpoint, {
             headers: args.headers,
             params: {
+              ...args.params,
               Offset: requestCount === 1 ? limit : offset + limit,
               Limit: limit,
             },


### PR DESCRIPTION
While auto-paginate variable was true the parameters were not being passed to the request being sent. 

This PR fixes the above